### PR TITLE
Add a new section for ontology information and improve test cases

### DIFF
--- a/tests/test_cases/test_case1.md
+++ b/tests/test_cases/test_case1.md
@@ -101,8 +101,7 @@ Subclass Of:
 
 ## PizzaBase
 ### Annotations
-Comment: Pizza dough that used as
-         a pizza base
+Comment: Pizza dough that used as a pizza base
 
 | Language      | Label         |
 | ------------- |:-------------:|
@@ -204,8 +203,3 @@ Domain:
 
 Range:
   - PizzaTopping
-
-
-# Data type
-- Literal
-- String

--- a/tests/test_cases/test_case1.md
+++ b/tests/test_cases/test_case1.md
@@ -1,3 +1,15 @@
+# Ontology description
+## Annotations
+### lable
+  - String
+
+### title
+  - Literal
+
+### licence
+  - Creative Commons Attribution 3.0 (CC BY 3.0)
+
+
 # Class Hierarchy
 -Thing
   - Food
@@ -179,8 +191,15 @@ Subclass Of:
 
 
 # Annotation property
-- Comment
-- Label
+## title
+### Annotations
+Comment: A name given to the resource
+
+## licence
+### Annotations
+Comment: A legal document giving official permission to do something with the resource.
+
+Lable: License
 
 
 # Object property

--- a/tests/test_cases/test_case1.md
+++ b/tests/test_cases/test_case1.md
@@ -1,10 +1,10 @@
 # Ontology description
 ## Annotations
-### lable
-  - String
+### label
+  - pizza
 
 ### title
-  - Literal
+  - pizza
 
 ### licence
   - Creative Commons Attribution 3.0 (CC BY 3.0)
@@ -199,7 +199,7 @@ Comment: A name given to the resource
 ### Annotations
 Comment: A legal document giving official permission to do something with the resource.
 
-Lable: License
+Label: License
 
 
 # Object property

--- a/tests/test_cases/test_case1.yaml
+++ b/tests/test_cases/test_case1.yaml
@@ -1,3 +1,11 @@
+annotations:
+  rdfs:label:
+    - pizza^^xsd:string
+  dc:title:
+    - pizza^^rdfs:Literal@en
+  dcterms:licence:
+    - Creative Commons Attribution 3.0 (CC BY 3.0)^^xsd:string
+
 owl:Class:
   owl:Thing: ""
   pizza:Food:
@@ -22,10 +30,9 @@ owl:Class:
         - Margherita^^rdfs:Literal@pt
     rdfs:subClassOf:
       - NamedPizza
-      owl:Restriction:
-        - hasTopping only (MozzarellaTopping or TomatoTopping)
-        - hasTopping some MozzarellaTopping
-        - hasTopping some TomatoTopping
+      - hasTopping only (MozzarellaTopping or TomatoTopping)
+      - hasTopping some MozzarellaTopping
+      - hasTopping some TomatoTopping
   pizza:MozzarellaTopping:
     annotations:
       rdfs:label:
@@ -51,13 +58,13 @@ owl:Class:
     rdfs:subClassOf:
       - Food
   pizza:PizzaBase:
-     annotations:
-       rdfs:comment:
-         - >
-           Pizza dough that used as
-           a pizza base^^xsd:string
-      rdfs:label:
-        - PizzaBase^^rdfs:Literal@en
+    annotations:
+      rdfs:comment:
+        - >
+          Pizza dough that used as
+          a pizza base^^xsd:string
+    rdfs:label:
+      - PizzaBase^^rdfs:Literal@en
     owl:disjointWith:
       - Pizza
       - PizzaTopping
@@ -82,11 +89,10 @@ owl:Class:
         - Rosa^^rdfs:Literal@pt
     rdfs:subClassOf:
       - NamedPizza
-      owl:Restriction:
-        - hasTopping only (GorgonzolaTopping or MozzarellaTopping or TomatoTopping)
-        - hasTopping some GorgonzolaTopping
-        - hasTopping some MozzarellaTopping
-        - hasTopping some TomatoTopping
+      - hasTopping only (GorgonzolaTopping or MozzarellaTopping or TomatoTopping)
+      - hasTopping some GorgonzolaTopping
+      - hasTopping some MozzarellaTopping
+      - hasTopping some TomatoTopping
   pizza:Spiciness:
     annotations:
       rdfs:comment: Spiciness of Pizza^^xsd:string
@@ -106,8 +112,16 @@ owl:Class:
       - PizzaTopping
 
 owl:AnnotationProperty:
-  rdfs:comment: ""
-  rdfs:label: ""
+  dc:title:
+    annotations:
+      rdfs:comment:
+        - A name given to the resource^^rdfs:Literal@en
+  dcterms:licence:
+    annotations:
+      rdfs:comment:
+        - A legal document giving official permission to do something with the resource.^^rdfs:Literal@en
+      rdfs:label:
+        - License^^rdfs:Literal@en
 
 owl:ObjectProperty:
   owl:topObjectProperty: ""

--- a/tests/test_cases/test_case2.md
+++ b/tests/test_cases/test_case2.md
@@ -316,8 +316,7 @@ Subproperty Of:
 Comment: Age of person which is the integer between 0 to 150
 
 ### Description
-Datatype Definitions:
-  - integer[>=0, <=150]
+Datatype Definition: integer[>=0, <=150]
 
 
 # Rule

--- a/tests/test_cases/test_case2.md
+++ b/tests/test_cases/test_case2.md
@@ -313,9 +313,14 @@ Subproperty Of:
 
 
 # Data type
-- Interger
-- Literal
-- String
+
+## personAge
+### Annotations
+Comment: Age of person which is the integer between 0 to 150
+
+### Description
+Datatype Definitions:
+  - integer[>=0, <=150]
 
 
 # Rule

--- a/tests/test_cases/test_case2.md
+++ b/tests/test_cases/test_case2.md
@@ -107,9 +107,6 @@ Subclass Of: Person
 ### Object Property
   - isSpouseOf
 
-# Annotation property
-- Label
-
 
 # Data Property
 

--- a/tests/test_cases/test_case2.yaml
+++ b/tests/test_cases/test_case2.yaml
@@ -167,7 +167,7 @@ owl:ObjectProperty:
       - isInLawOf
 
 rdfs:Datatype:
-  mao:personAge:
+  family:personAge:
     owl:equivalentClass:
       - xsd:integer[>=0, <=150]
     annotations:

--- a/tests/test_cases/test_case2.yaml
+++ b/tests/test_cases/test_case2.yaml
@@ -48,7 +48,6 @@ owl:Class:
         - Person and (isSpouseOf some Person)
     rdfs:subClassOf: Person
 
-
 owl:DataProperty:
   owl:topDataProperty: ""
   family:hasBirthYear:

--- a/tests/test_cases/test_case2.yaml
+++ b/tests/test_cases/test_case2.yaml
@@ -48,8 +48,6 @@ owl:Class:
         - Person and (isSpouseOf some Person)
     rdfs:subClassOf: Person
 
-owl:AnnnotationProperty:
-  rdfs:label: ""
 
 owl:DataProperty:
   owl:topDataProperty: ""

--- a/tests/test_cases/test_case2.yaml
+++ b/tests/test_cases/test_case2.yaml
@@ -165,3 +165,12 @@ owl:ObjectProperty:
       - Person
     rdfs:subPropertyOf:
       - isInLawOf
+
+rdfs:Datatype:
+  mao:personAge:
+    owl:equivalentClass:
+      - xsd:integer[>=0, <=150]
+    annotations:
+      rdfs:comment:
+        - Age of person which is the integer between 0 to 150
+

--- a/tests/test_cases/test_case2_rules.yaml
+++ b/tests/test_cases/test_case2_rules.yaml
@@ -1,8 +1,5 @@
 rules:
   aunt:
     rule:
-    - >
-      family:Person(?p) ^ family:Person(?a) ^ family:Person(?c) ^
-      family:isSiblingOf(?p,?a) ^ family:isParentOf(?p,?c) ^ family:hasGender(?a,family:Female)
-      -> family:hasAunt(?c,?a)
+    - family:Person(?p) ^ family:Person(?a) ^ family:Person(?c) ^ family:isSiblingOf(?p,?a) ^ family:isParentOf(?p,?c) ^ family:hasGender(?a,family:Female) -> family:hasAunt(?c,?a)
     rdfs:comment: ""


### PR DESCRIPTION
## Major changes

### Test case 1 (`test_case1.yaml`)
- Added a new section for collecting general information of an ontology
- Added annotation properties from Dublin Core in `owl:AnnotationProperty` section
- Edited .md file to match .yaml file
- Fixed syntax error in `test_case1.yaml` (thx @theethaj who pointed this out) by grouping a subclass with necessary conditions

Before
```
rdfs:subClassOf:
  - NamedPizza
  owl:Restriction:
    - hasTopping only (MozzarellaTopping or TomatoTopping)
    - hasTopping some MozzarellaTopping
    - hasTopping some TomatoTopping
```

After
```
rdfs:subClassOf:
  - NamedPizza
  - hasTopping only (MozzarellaTopping or TomatoTopping)
  - hasTopping some MozzarellaTopping
  - hasTopping some TomatoTopping
```

### Test case 2 (`test_case2.yaml`)
- Added custom datatype in `rdfs:Datatype` section of `test_case2.yaml`
- Edited .md file to match .yaml file
