### PR TITLE
Fix yaml testcase

### DIFF
--- a/tests/test_cases/test_case1.md
+++ b/tests/test_cases/test_case1.md
@@ -11,7 +11,7 @@
 
 
 # Class Hierarchy
--Thing
+- Thing
   - Food
     - Pizza
       - NamedPizza

--- a/tests/test_cases/test_case2.yaml
+++ b/tests/test_cases/test_case2.yaml
@@ -10,7 +10,7 @@ owl:Class:
     owl:disjointWith: Person
     owl:equivalentClass:
       owl:Restriction:
-        - {Female, Male, Non-binary}
+        - "{Female, Male, Non-binary}"
     rdfs:subClassOf: Thing
   family:Parent:
     annotations:


### PR DESCRIPTION
This PR fixes syntax error in `test_case1.yaml` and `test_case2.yaml` caused by wrong indentation and unescaped characters respectively.