### PR TITLE
Improve performance for sa_autowrite for large data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,8 +175,11 @@ dmypy.json
 
 ###### PROJECT ######
 
-database/
-out/
+# Large data files
+tests/large_data/
+
+# Autogen folder
+autogen_db_models
 
 
 ##### MISC #####

--- a/.gitignore
+++ b/.gitignore
@@ -176,7 +176,7 @@ dmypy.json
 ###### PROJECT ######
 
 # Large data files
-tests/large_data/
+tests/data/large/
 
 # Autogen folder
 autogen_db_models

--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,7 @@ dmypy.json
 
 # Large data files
 tests/data/large/
+*.sqlite3
 
 # Autogen folder
 autogen_db_models

--- a/autogen_db_models/imdb/__init__.py
+++ b/autogen_db_models/imdb/__init__.py
@@ -1,0 +1,12 @@
+# import modules to run it through declarative base
+from .name_basics import NameBasics
+from .title_akas import TitleAkas
+from .title_akas import TitleAkas
+from .title_basics import TitleBasics
+from .title_basics import TitleBasics
+from .title_crew import TitleCrew
+from .title_episode import TitleEpisode
+from .title_principals import TitlePrincipals
+from .title_ratings import TitleRatings
+
+models = [NameBasics, TitleAkas, TitleAkas, TitleBasics, TitleBasics, TitleCrew, TitleEpisode, TitlePrincipals, TitleRatings]

--- a/autogen_db_models/imdb/base.py
+++ b/autogen_db_models/imdb/base.py
@@ -1,0 +1,3 @@
+from sqlalchemy.ext.declarative import declarative_base
+
+Base = declarative_base()

--- a/autogen_db_models/imdb/name_basics.py
+++ b/autogen_db_models/imdb/name_basics.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base
+
+
+class NameBasics(Base):
+    __tablename__ = 'name_basics'
+
+    # _id = Column(Integer)                      # unique: 10000, val = [0,9999]
+    nconst = Column(String, primary_key=True)  # unique: 10000, len = {9}
+    primaryName = Column(String)               # unique: 9880, len = [3,35]
+    birthYear = Column(String)                 # unique: 164, len = {2,4}
+    deathYear = Column(String)                 # unique: 131, len = {2,4}
+    primaryProfession = Column(String)         # unique: 1552, len = [0,63]
+    knownForTitles = Column(String)            # unique: 9926, len = [2,42]
+
+    def __repr__(self):
+        return f"<NameBasics(nconst='{self.nconst}', primaryName='{self.primaryName}', birthYear='{self.birthYear}', deathYear='{self.deathYear}', primaryProfession='{self.primaryProfession}', knownForTitles='{self.knownForTitles}')>"

--- a/autogen_db_models/imdb/title_akas.py
+++ b/autogen_db_models/imdb/title_akas.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base
+
+
+class TitleAkas(Base):
+    __tablename__ = 'title_akas'
+
+    # _id = Column(Integer, )                       # unique: 10000, val = [0,9999]
+    titleId = Column(String, primary_key=True)    # unique: 4421, len = {9}
+    ordering = Column(Integer, primary_key=True)  # unique: 41, val = [1,41]
+    title = Column(String)                        # unique: 8113, len = [2,138]
+    region = Column(String)                       # unique: 44, len = {2,3,4}
+    language = Column(String)                     # unique: 16, len = {2,3}
+    types = Column(String)                        # unique: 9, len = {2,3,5,7,8,11}
+    attributes = Column(String)                   # unique: 40, len = [2,36]
+    isOriginalTitle = Column(Integer)             # unique: 2, val = [0,1]
+
+    def __repr__(self):
+        return f"<TitleAkas(titleId='{self.titleId}', ordering='{self.ordering}', title='{self.title}', region='{self.region}', language='{self.language}', types='{self.types}', attributes='{self.attributes}', isOriginalTitle='{self.isOriginalTitle}')>"

--- a/autogen_db_models/imdb/title_basics.py
+++ b/autogen_db_models/imdb/title_basics.py
@@ -1,0 +1,21 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base
+
+
+class TitleBasics(Base):
+    __tablename__ = 'title_basics'
+
+    # _id = Column(Integer)                      # unique: 10000, val = [0,9999]
+    tconst = Column(String, primary_key=True)  # unique: 10000, len = {9}
+    titleType = Column(String)                 # unique: 2, len = {5}
+    primaryTitle = Column(String)              # unique: 9625, len = [2,114]
+    originalTitle = Column(String)             # unique: 9651, len = [2,114]
+    isAdult = Column(Integer)                  # unique: 1, val = [0,0]
+    startYear = Column(Integer)                # unique: 33, val = [1892,1936]
+    endYear = Column(String)                   # unique: 1, len = {2}
+    runtimeMinutes = Column(String)            # unique: 152, len = {1,2,3,4}
+    genres = Column(String)                    # unique: 272, len = [2,27]
+
+    def __repr__(self):
+        return f"<tconst='{self.tconst}', titleType='{self.titleType}', primaryTitle='{self.primaryTitle}', originalTitle='{self.originalTitle}', isAdult='{self.isAdult}', startYear='{self.startYear}', endYear='{self.endYear}', runtimeMinutes='{self.runtimeMinutes}', genres='{self.genres}')>"

--- a/autogen_db_models/imdb/title_crew.py
+++ b/autogen_db_models/imdb/title_crew.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base
+
+
+class TitleCrew(Base):
+    __tablename__ = 'title_crew'
+
+    # _id = Column(Integer)                      # unique: 10000, val = [0,9999]
+    tconst = Column(String, primary_key=True)  # unique: 10000, len = {9}
+    directors = Column(String)                 # unique: 1419, len = {2,9,10,19,29,39,59,69}
+    writers = Column(String)                   # unique: 3751, len = [2,189]
+
+    def __repr__(self):
+        return f"<TitleCrew(tconst='{self.tconst}', directors='{self.directors}', writers='{self.writers}')>"

--- a/autogen_db_models/imdb/title_episode.py
+++ b/autogen_db_models/imdb/title_episode.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base
+
+
+class TitleEpisode(Base):
+    __tablename__ = 'title_episode'
+
+    _id = Column(Integer)                      # unique: 10000, val = [0,9999]
+    tconst = Column(String, primary_key=True)  # unique: 10000, len = {9}
+    parentTconst = Column(String)              # unique: 1502, len = {9,10}
+    seasonNumber = Column(String)              # unique: 53, len = {1,2,4}
+    episodeNumber = Column(String)             # unique: 595, len = {1,2,3,4}
+
+    def __repr__(self):
+        return f"<TitleEpisode(tconst='{self.tconst}', parentTconst='{self.parentTconst}', seasonNumber='{self.seasonNumber}', episodeNumber='{self.episodeNumber}')>"

--- a/autogen_db_models/imdb/title_principals.py
+++ b/autogen_db_models/imdb/title_principals.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, Integer, String
+
+from .base import Base
+
+
+class TitlePrincipals(Base):
+    __tablename__ = 'title_principals'
+
+    _id = Column(Integer, primary_key=True)  # unique: 10000, val = [0,9999]
+    tconst = Column(String)                  # unique: 2091, len = {9}
+    ordering = Column(Integer)               # unique: 10, val = [1,10]
+    nconst = Column(String)                  # unique: 1975, len = {9,10}
+    category = Column(String)                # unique: 10, len = {4,5,6,7,8,15,19}
+    job = Column(String)                     # unique: 103, len = [2,98]
+    characters = Column(String)              # unique: 3632, len = [2,66]
+
+    def __repr__(self):
+        return f"<TitlePrincipals(_id='{self._id}', tconst='{self.tconst}', ordering='{self.ordering}', nconst='{self.nconst}', category='{self.category}', job='{self.job}', characters='{self.characters}')>"

--- a/autogen_db_models/imdb/title_ratings.py
+++ b/autogen_db_models/imdb/title_ratings.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Column, Float, Integer, String
+
+from .base import Base
+
+
+class TitleRatings(Base):
+    __tablename__ = 'title_ratings'
+
+    # _id = Column(Integer)                      # unique: 10000, val = [0,9999]
+    tconst = Column(String, primary_key=True)  # unique: 10000, len = {9}
+    averageRating = Column(Float)              # unique: 84, val = [1.0,9.7]
+    numVotes = Column(Integer)                 # unique: 1391, val = [5,164537]
+
+    def __repr__(self):
+        return f"<TitleRatings(tconst='{self.tconst}', averageRating='{self.averageRating}', numVotes='{self.numVotes}')>"

--- a/dirs.py
+++ b/dirs.py
@@ -1,5 +1,5 @@
 from pathlib import Path
 
+__all__ = ['ROOT_DIR']
+
 ROOT_DIR = Path(__file__).parent
-DATA_SRC_DIR = ROOT_DIR / 'database/src'
-DATA_OUT_DIR = ROOT_DIR / 'database/out'

--- a/extended_csv.py
+++ b/extended_csv.py
@@ -109,6 +109,7 @@ def read_xsv(file: IO,
     """
     kwargs = {
         'fieldnames': fieldnames,
+        'dialect': dialect,
     }
 
     if not first_line_is_column_header and fieldnames is None:
@@ -119,10 +120,10 @@ def read_xsv(file: IO,
         num_cols = len(first_line.split(delimiter))
         kwargs['fieldnames'] = [f'Column {i + 1}' for i in range(num_cols)]
 
-    reader = csv.DictReader(file, **select_not_null(kwargs, 'fieldnames'))
-
     if first_line_is_column_header and fieldnames is not None:
         raise NotImplementedError("Changing column names isn't supported for simplicity")
+
+    reader = csv.DictReader(file, **select_not_null(kwargs, 'fieldnames', 'dialect'))
 
     stop = None
     if load_at_most is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ python-decouple
 sqlalchemy
 PyMySQL
 PyMSSQL
-stringcase
 pyyaml
 pandas

--- a/sa_autowrite/README.md
+++ b/sa_autowrite/README.md
@@ -12,3 +12,22 @@ Base.metadata.create_all(engine)
 
 insert_data('tests/data/csv/', 'autogen_db_models/')
 ```
+
+Sample script for large files e.g. IMDb (put those tsv files in /tests/data/large/imdb/)
+
+```python
+from dirs import ROOT_DIR
+from engine import engine
+from sa_autowrite.main import insert_data, write_models
+
+IMDB_FOLDER = ROOT_DIR / f'tests/data/large/imdb/'
+
+write_models(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb', max_lines=10000)
+
+
+from autogen_db_models.imdb.base import Base
+
+Base.metadata.create_all(engine)
+
+insert_data(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb')
+```

--- a/sa_autowrite/README.md
+++ b/sa_autowrite/README.md
@@ -2,7 +2,8 @@ Sample script (put this in a file in root dir):
 
 ```python
 from engine import engine
-from sa_autowrite.main import insert_data, write_models
+from sa_autowrite.create import write_models
+from sa_autowrite.insert import insert_data
 
 # Write models from data in autogen_db_models/ directory
 write_models('tests/data/csv/', 'autogen_db_models/', max_lines=1000)
@@ -18,16 +19,27 @@ Sample script for large files e.g. IMDb (put those tsv files in /tests/data/larg
 ```python
 from dirs import ROOT_DIR
 from engine import engine
-from sa_autowrite.main import insert_data, write_models
+# from sa_autowrite.create import write_models
+from sa_autowrite.insert import insert_xsv_data
 
 IMDB_FOLDER = ROOT_DIR / f'tests/data/large/imdb/'
 
-write_models(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb', max_lines=10000)
+# write_models(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb', max_lines=10000)
 
 
 from autogen_db_models.imdb.base import Base
+from autogen_db_models.imdb import TitleCrew
 
 Base.metadata.create_all(engine)
+confirmation = input("Confirm table 'TitleCrew' deletion (y/N): ")
+if confirmation == 'y':
+    TitleCrew.__table__.drop(engine)
+    Base.metadata.create_all(engine)
+elif confirmation == 'N':
+    pass
+else:
+    raise AssertionError("invalid input")
 
-insert_data(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb')
+
+insert_xsv_data(IMDB_FOLDER / 'title.crew.tsv', TitleCrew, chunksize=30_000, encoding='utf-8', null_values=['\\N'], ignore_cols=['_id'], skip_rows_data=30_000, read_lines_data=30_000)
 ```

--- a/sa_autowrite/README.md
+++ b/sa_autowrite/README.md
@@ -60,7 +60,7 @@ Sample script to read data from IMDb .list files
 from sa_autowrite.parsers import parse_imdb_list
 from dirs import ROOT_DIR
 
-for file in ['countries.list', 'certificates.lit', 'production-companies.list']:
+for file in ['countries.list', 'certificates.list', 'production-companies.list']:
     for df in parse_imdb_list(ROOT_DIR / f'tests/data/large/imdb/{file}', encoding='windows-1252', chunksize=10000):
         print(df)
 ```

--- a/sa_autowrite/README.md
+++ b/sa_autowrite/README.md
@@ -54,3 +54,13 @@ for filename, clsname in [
                     skip_rows_data=0, read_lines_data=None,
                     verbose=1)
 ```
+
+Sample script to read data from IMDb .list files
+```python
+from sa_autowrite.parsers import parse_imdb_list
+from dirs import ROOT_DIR
+
+for file in ['countries.list', 'certificates.lit', 'production-companies.list']:
+    for df in parse_imdb_list(ROOT_DIR / f'tests/data/large/imdb/{file}', encoding='windows-1252', chunksize=10000):
+        print(df)
+```

--- a/sa_autowrite/README.md
+++ b/sa_autowrite/README.md
@@ -1,45 +1,56 @@
-Sample script (put this in a file in root dir):
+# Module: sa_autowrite
 
-```python
-from engine import engine
-from sa_autowrite.create import write_models
-from sa_autowrite.insert import insert_data
+### Description
 
-# Write models from data in autogen_db_models/ directory
-write_models('tests/data/csv/', 'autogen_db_models/', max_lines=1000)
+Features:
+- Write SA models from data (CSV, TSV, ...)
+- Show stats or data read to create models for human checking
+- Insert data into database
 
-from autogen_db_models.base import Base
-Base.metadata.create_all(engine)
+### Getting Started
 
-insert_data('tests/data/csv/', 'autogen_db_models/')
-```
-
-Sample script for large files e.g. IMDb (put those tsv files in /tests/data/large/imdb/)
+Sample script to create models
 
 ```python
 from dirs import ROOT_DIR
+from sa_autowrite.create import write_models
+
+IMDB_FOLDER = ROOT_DIR / 'tests/data/large/imdb/'
+
+write_models(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb', max_lines=10000)
+```
+
+Sample script to insert data
+```python
+from dirs import ROOT_DIR
 from engine import engine
-# from sa_autowrite.create import write_models
 from sa_autowrite.insert import insert_xsv_data
 
-IMDB_FOLDER = ROOT_DIR / f'tests/data/large/imdb/'
-
-# write_models(IMDB_FOLDER, ROOT_DIR / f'autogen_db_models/imdb', max_lines=10000)
-
-
 from autogen_db_models.imdb.base import Base
-from autogen_db_models.imdb import TitleCrew
+from autogen_db_models.imdb import NameBasics, TitleAkas, TitleAkas, TitleBasics, TitleBasics, TitleCrew, TitleEpisode, TitlePrincipals, TitleRatings
 
-Base.metadata.create_all(engine)
-confirmation = input("Confirm table 'TitleCrew' deletion (y/N): ")
-if confirmation == 'y':
-    TitleCrew.__table__.drop(engine)
-    Base.metadata.create_all(engine)
-elif confirmation == 'N':
-    pass
-else:
-    raise AssertionError("invalid input")
+IMDB_FOLDER = ROOT_DIR / 'tests/data/large/imdb/'
 
+for filename, clsname in [
+    (IMDB_FOLDER / 'name.basics.tsv', NameBasics),
+    # (IMDB_FOLDER / 'title.akas.tsv', TitleAkas),
+    # (IMDB_FOLDER / 'title.basics.tsv', TitleBasics),
+    # (IMDB_FOLDER / 'title.crew.tsv', TitleCrew),
+    # (IMDB_FOLDER / 'title.episode.tsv', TitleEpisode),
+    # (IMDB_FOLDER / 'title.principals.tsv', TitlePrincipals),
+    # (IMDB_FOLDER / 'title.ratings.tsv', TitleRatings),
+]:
+    confirmation = input(f"Confirm table '{clsname.__name__}' deletion (y/N): ")
+    if confirmation == 'y':
+        clsname.__table__.drop(engine)
+        Base.metadata.create_all(engine)
+    elif confirmation == 'N':
+        pass
+    else:
+        raise AssertionError("invalid input")
 
-insert_xsv_data(IMDB_FOLDER / 'title.crew.tsv', TitleCrew, chunksize=30_000, encoding='utf-8', null_values=['\\N'], ignore_cols=['_id'], skip_rows_data=30_000, read_lines_data=30_000)
+    insert_xsv_data(filename, clsname, chunksize=20_000, encoding='utf-8',
+                    null_values=['\\N'], ignore_cols=['_id'],
+                    skip_rows_data=0, read_lines_data=None,
+                    verbose=1)
 ```

--- a/sa_autowrite/create.py
+++ b/sa_autowrite/create.py
@@ -120,6 +120,8 @@ def write_models(in_directory: Union[str, Path],
     lines = ['# import modules to run it through declarative base'] + \
             [f'from .{module_name} import {class_name}' for module_name, class_name in module_class] + \
             ['']
+    lines += [f"models = [{', '.join(class_name for _, class_name in module_class)}]",
+              '']
     open_and_write_file((out_directory / '__init__.py'), '\n'.join(lines))
 
 

--- a/sa_autowrite/hint.py
+++ b/sa_autowrite/hint.py
@@ -7,24 +7,22 @@ from sqlalchemy.sql.schema import Table
 
 class DeclaredModel(ABC):
     @abstractmethod
-    def __init__(self, *args, **kwargs):
-        pass
+    def __init__(self, *args, **kwargs): ...
 
     @property
+    @classmethod
     @abstractmethod
-    def _sa_class_manager(self) -> Dict[str, InstrumentedAttribute]:
-        pass
+    def _sa_class_manager(self) -> Dict[str, InstrumentedAttribute]: ...
 
     @property
+    @classmethod
     @abstractmethod
-    def __tablename__(self) -> str:
-        pass
+    def __tablename__(self) -> str: ...
 
     @property
+    @classmethod
     @abstractmethod
-    def __table__(self) -> Table:
-        pass
+    def __table__(self) -> Table: ...
 
     @abstractmethod
-    def __call__(self, *args, **kwargs) -> 'DeclaredModel':
-        pass
+    def __call__(self, *args, **kwargs) -> 'DeclaredModel': ...

--- a/sa_autowrite/insert.py
+++ b/sa_autowrite/insert.py
@@ -74,9 +74,10 @@ def insert_xsv_data(filename: Union[str, Path],
         skip_rows_data = 1
     if skip_rows_data % chunksize != 0:
         raise ValueError(f"skip_rows_data must be a multiple of chunk_size")
-    if read_lines_data % chunksize != 0:
-        raise ValueError(f"read_lines_data must be a multiple of chunk_size")
-    read_until = skip_rows_data + read_lines_data
+    if read_lines_data is not None:
+        if read_lines_data % chunksize != 0:
+            raise ValueError(f"read_lines_data must be a multiple of chunk_size")
+        read_until = skip_rows_data + read_lines_data
 
     info = _get_info_from_filename(filename.name)
     dialect = get_dialect_from_suffix(info['format'])
@@ -100,7 +101,7 @@ def insert_xsv_data(filename: Union[str, Path],
         session.commit()
         if verbose > 0:
             print(f'Committed till row {counter}')
-        if counter == read_until:
+        if read_lines_data is not None and counter == read_until:
             break
 
 

--- a/sa_autowrite/insert.py
+++ b/sa_autowrite/insert.py
@@ -11,6 +11,7 @@ from sa_autowrite.hint import DeclaredModel
 from sa_autowrite.model import TYPE_CONVERTER, DEF_TYPE
 from sa_autowrite.create import _get_info_from_filename
 from utils.str_utils import snake_to_capwords, snake_case
+from sqlalchemy.sql.sqltypes import TypeEngine
 
 
 # def read_in_chunks(file_object, chunk_size=1024):
@@ -21,11 +22,12 @@ from utils.str_utils import snake_to_capwords, snake_case
 #         if not data:
 #             break
 #         yield data
-def get_converter(col_type: str) -> Callable[[str], Any]:
-    type_ = repr(col_type)[:-2]
-    if type_ != 'String':
-        return TYPE_CONVERTER[DEF_TYPE[type_]]
-    return str
+
+
+def get_converter(col_type: TypeEngine) -> Callable[[str], Any]:
+    if col_type.python_type == str:
+        return str
+    return TYPE_CONVERTER[col_type.python_type]
 
 
 def create_instance(cls: Type[DeclaredModel], row: pd.Series,

--- a/sa_autowrite/insert.py
+++ b/sa_autowrite/insert.py
@@ -50,7 +50,8 @@ def create_instance(cls: Type[DeclaredModel], row: pd.Series,
         assert val is not None
         if val in null_values:
             val = None
-        val = get_converter(col.type)(val)
+        else:
+            val = get_converter(col.type)(val)
         data[col.name] = val
     return cls(**data)
 

--- a/sa_autowrite/insert.py
+++ b/sa_autowrite/insert.py
@@ -1,0 +1,172 @@
+from importlib import import_module
+from pathlib import Path
+from typing import Union, List, Dict, IO, Type, Callable, Any
+
+import pandas as pd
+
+from dirs import ROOT_DIR
+from engine import Session
+from extended_csv import get_dialect_from_suffix
+from sa_autowrite.hint import DeclaredModel
+from sa_autowrite.model import TYPE_CONVERTER, DEF_TYPE
+from sa_autowrite.create import _get_info_from_filename
+from utils.str_utils import snake_to_capwords, snake_case
+
+
+# def read_in_chunks(file_object, chunk_size=1024):
+#     """Lazy function (generator) to read a file piece by piece.
+#     Default chunk size: 1k."""
+#     while True:
+#         data = file_object.read(chunk_size)
+#         if not data:
+#             break
+#         yield data
+def get_converter(col_type: str) -> Callable[[str], Any]:
+    type_ = repr(col_type)[:-2]
+    if type_ != 'String':
+        return TYPE_CONVERTER[DEF_TYPE[type_]]
+    return str
+
+
+def create_instance(cls: Type[DeclaredModel], row: pd.Series,
+                    *,
+                    null_values: List[str] = None,
+                    ignore_cols: List[str] = None,
+                    ) -> DeclaredModel:
+    if null_values is None:
+        null_values = []
+    if ignore_cols is None:
+        ignore_cols = []
+
+    data = {}
+
+    for col in cls.__table__.columns:
+        if col.name in ignore_cols:
+            continue
+
+        val = row.get(col.name)
+        assert val is not None
+        if val in null_values:
+            val = None
+        val = get_converter(col.type)(val)
+        data[col.name] = val
+    return cls(**data)
+
+
+def insert_xsv_data(filename: Union[str, Path],
+                    model_cls: Type[DeclaredModel],
+                    *,
+                    chunksize: int,
+                    null_values: List[str],
+                    ignore_cols: List[str],
+                    encoding: str = None,
+                    skip_rows_data: int = None,
+                    read_lines_data: int = None,
+                    ):
+    filename = Path(filename)
+
+    if encoding is None:
+        encoding = 'utf-8'
+    if skip_rows_data is None:
+        skip_rows_data = 1
+    if skip_rows_data % chunksize != 0:
+        raise ValueError(f"skip_rows_data must be a multiple of chunk_size")
+    if read_lines_data % chunksize != 0:
+        raise ValueError(f"read_lines_data must be a multiple of chunk_size")
+    read_until = skip_rows_data + read_lines_data
+
+    info = _get_info_from_filename(filename.name)
+    dialect = get_dialect_from_suffix(info['format'])
+    print(f"Opening {filename.name}")
+
+    reader = pd.read_csv(filename, encoding=encoding, dialect=dialect, chunksize=chunksize)
+    session = Session()
+    counter = 0
+    for chunk in reader:
+        chunk: pd.DataFrame
+        if counter < skip_rows_data:
+            counter += chunksize
+            continue
+        for row in chunk.iterrows():
+            line, series = row
+            counter += 1
+            session.add(create_instance(model_cls, series, null_values=null_values, ignore_cols=ignore_cols))
+            if counter % 5000 == 0:
+                print(f"Added till row {counter}")
+        session.commit()
+        print(f'Committed till row {counter}')
+        if counter == read_until:
+            break
+
+
+# Depreciated
+def insert_data(in_directory: Union[str, Path],
+                out_directory: Union[str, Path],
+                *,
+                null_values: List[str]) -> None:
+    # Ensure directories are of type 'Path'
+    in_directory = Path(in_directory)
+    out_directory = Path(out_directory)
+
+    module_names = []
+    for pyfile in out_directory.glob('*.py'):
+        if pyfile.name in ['base.py', '__init__.py']:
+            continue
+        module_names.append(pyfile.stem)
+    class_names = [snake_to_capwords(name) for name in module_names]
+
+    # invalidate_caches()
+    path_to_package = Path(out_directory).relative_to(ROOT_DIR.absolute())
+    package_path = str(path_to_package).replace('/', '.').replace('\\', '.')
+    generated_package = import_module(package_path)
+    models: Dict[str, DeclaredModel] = {class_name: generated_package.__dict__[class_name] for class_name in
+                                        class_names}
+
+    #
+    session = Session()
+    for csvfile in in_directory.glob('*.*sv'):
+        info = _get_info_from_filename(csvfile.name)
+        model_name = info['name']
+        dialect = get_dialect_from_suffix(info['format'])
+        print(f"Opening {csvfile}")
+
+        class_name = snake_to_capwords(snake_case(model_name))
+        if class_name not in class_names:
+            raise AssertionError("class name from data files doesn't match models")
+        print(f"Writing from {csvfile} to {class_name}\n")
+        counter = 0
+        for chunk in pd.read_csv(csvfile, chunksize=10_000, dialect=dialect):
+            df = chunk
+            instances = []
+            for i in range(len(df)):
+                model = models[class_name]
+                datab = {}
+                for col in model.__table__.columns:
+                    try:
+                        val = df.get(col.name)[counter]
+                        type_ = repr(col.type)[:-2]
+                        if type_ != 'String':
+                            try:
+                                val = TYPE_CONVERTER[DEF_TYPE[type_]](val)
+                            except ValueError:
+                                if val in null_values:
+                                    val = None
+                                else:
+                                    raise
+                        datab[col.name] = val
+                    except TypeError:
+                        if col.name == '_id':
+                            pass
+                        else:
+                            raise
+                instance = model(**datab)
+                instances.append(instance)
+                counter += 1
+                if counter % 1000 == 0:
+                    session.add_all(instances)
+                    session.commit()
+                    instances = []
+                    print(f'Commited {counter}')
+            if instances:
+                session.add_all(instances)
+                session.commit()

--- a/sa_autowrite/insert.py
+++ b/sa_autowrite/insert.py
@@ -173,7 +173,7 @@ def insert_data(in_directory: Union[str, Path],
                     session.add_all(instances)
                     session.commit()
                     instances = []
-                    print(f'Commited {counter}')
+                    print(f'Committed {counter}')
             if instances:
                 session.add_all(instances)
                 session.commit()

--- a/sa_autowrite/insert.py
+++ b/sa_autowrite/insert.py
@@ -62,6 +62,7 @@ def insert_xsv_data(filename: Union[str, Path],
                     encoding: str = None,
                     skip_rows_data: int = None,
                     read_lines_data: int = None,
+                    verbose: int = 2
                     ):
     filename = Path(filename)
 
@@ -91,10 +92,12 @@ def insert_xsv_data(filename: Union[str, Path],
             line, series = row
             counter += 1
             session.add(create_instance(model_cls, series, null_values=null_values, ignore_cols=ignore_cols))
-            if counter % 5000 == 0:
-                print(f"Added till row {counter}")
+            if verbose > 1:
+                if counter % 5000 == 0:
+                    print(f"Added till row {counter}")
         session.commit()
-        print(f'Committed till row {counter}')
+        if verbose > 0:
+            print(f'Committed till row {counter}')
         if counter == read_until:
             break
 

--- a/sa_autowrite/main.py
+++ b/sa_autowrite/main.py
@@ -97,15 +97,14 @@ def write_models(in_directory: Union[str, Path],
         info = _get_info_from_filename(csvfile.name)
         model_name = info['name']
         dialect = get_dialect_from_suffix(info['format'])
-        with open(csvfile, 'r', encoding='utf-8') as f:
-            print(f"Reading from {csvfile}")
-            module_name = snakecase(model_name)
-            class_name = pascalcase(model_name)
-            module_class.append((model_name, class_name))
-            write_model(out_directory / f'{module_name}.py',
-                        class_name,
-                        read_xsv_file(csvfile, dialect=dialect, load_at_most=max_lines))
-            print(f"Writing to {(out_directory / f'{snakecase(model_name)}.py')}\n")
+        print(f"Reading from {csvfile}")
+        module_name = snakecase(model_name)
+        class_name = snake_to_capwords(module_name)
+        module_class.append((module_name, class_name))
+        write_model(out_directory / f'{module_name}.py',
+                    class_name,
+                    read_xsv_file(csvfile, encoding='utf-8', dialect=dialect, load_at_most=max_lines))
+        print(f"Writing to {(out_directory / f'{snakecase(model_name)}.py')}\n")
 
     # Check for required files
     has_base = False
@@ -153,7 +152,7 @@ def insert_data(in_directory: Union[str, Path],
             class_name = pascalcase(model_name)
             if class_name not in class_names:
                 raise AssertionError("class name from data files doesn't match models")
-            data = read_xsv_file(csvfile, dialect=dialect)
+            data = read_xsv_file(csvfile, encoding='utf-8', dialect=dialect)
             df = DataFrame(data)
             instances = []
             for i in range(len(df)):

--- a/sa_autowrite/main.py
+++ b/sa_autowrite/main.py
@@ -15,6 +15,8 @@ from utils.dict_utils import select_not_null
 from utils.io_utils import open_and_write_file
 from utils.str_utils import snake_to_capwords
 
+__all__ = ['write_models', 'insert_data', 'write_model', 'write_base']
+
 
 def write_model(file: Union[IO, str, Path],
                 model_name: str,

--- a/sa_autowrite/main.py
+++ b/sa_autowrite/main.py
@@ -14,6 +14,7 @@ from sa_autowrite.model import DEF_TYPE, TYPE_CONVERTER, TYPE_DEF, Table
 from utils.dict_utils import select_not_null
 from utils.io_utils import open_and_write_file
 from utils.str_utils import snake_to_capwords
+from dirs import ROOT_DIR
 
 __all__ = ['write_models', 'insert_data', 'write_model', 'write_base']
 
@@ -142,7 +143,9 @@ def insert_data(in_directory: Union[str, Path],
     class_names = [snake_to_capwords(name) for name in module_names]
 
     # invalidate_caches()
-    generated_module = import_module('autogen_db_models')
+    path_to_module = Path(out_directory).relative_to(ROOT_DIR.absolute())
+    package_path = str(path_to_module).replace('/', '.').replace('\\', '.')
+    generated_module = import_module(package_path)
     models: Dict[str, DeclaredModel] = {class_name: generated_module.__dict__[class_name] for class_name in class_names}
 
     #

--- a/sa_autowrite/main.py
+++ b/sa_autowrite/main.py
@@ -162,6 +162,7 @@ def insert_data(in_directory: Union[str, Path],
             data = read_xsv_file(csvfile, encoding='utf-8', dialect=dialect)
             df = DataFrame(data)
             instances = []
+            counter = 0
             for i in range(len(df)):
                 model = models[class_name]
                 datab = {}
@@ -179,6 +180,12 @@ def insert_data(in_directory: Union[str, Path],
                             raise
                 instance = model(**datab)
                 instances.append(instance)
+                counter += 1
+                if counter % 1000 == 0:
+                    session.add_all(instances)
+                    session.commit()
+                    instances = []
+                    print(f'Commited {counter}')
             session.add_all(instances)
             session.commit()
 

--- a/sa_autowrite/main.py
+++ b/sa_autowrite/main.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from stringcase import pascalcase, snakecase
 
 from engine import Session
-from extended_csv import get_dialect_from_suffix, read_xsv_file
+from extended_csv import get_dialect_from_suffix, read_xsv_file, read_xsv
 from sa_autowrite.hint import DeclaredModel
 from sa_autowrite.model import DEF_TYPE, TYPE_CONVERTER, TYPE_DEF, Table
 from utils.dict_utils import select_not_null
@@ -154,12 +154,13 @@ def insert_data(in_directory: Union[str, Path],
         info = _get_info_from_filename(csvfile.name)
         model_name = info['name']
         dialect = get_dialect_from_suffix(info['format'])
-        with open(csvfile, 'r', encoding='utf-8') as f:
-            print(f"Reading from {csvfile}")
+        print(f"Opening {csvfile}")
+        with open(csvfile, 'r', encoding='utf-8') as file:
             class_name = snake_to_capwords(snakecase(model_name))
             if class_name not in class_names:
                 raise AssertionError("class name from data files doesn't match models")
-            data = read_xsv_file(csvfile, encoding='utf-8', dialect=dialect)
+            print(f"Writing from {csvfile} to {class_name}\n")
+            data = read_xsv(file, dialect=dialect)
             df = DataFrame(data)
             instances = []
             counter = 0
@@ -188,8 +189,6 @@ def insert_data(in_directory: Union[str, Path],
                     print(f'Commited {counter}')
             session.add_all(instances)
             session.commit()
-
-            print(f"Writing from {csvfile} to {class_name}\n")
 
 
 if __name__ == '__main__':

--- a/sa_autowrite/parsers.py
+++ b/sa_autowrite/parsers.py
@@ -1,0 +1,31 @@
+from abc import abstractmethod
+from typing import IO, Iterable, Sequence, overload, TypeVar
+from utils.dict_utils import select_not_null
+import pandas as pd
+
+__all__ = ['MAP']
+
+
+def parse_csv(file: IO, chunksize: int = None) -> pd.DataFrame:
+    kwd = {
+        chunksize: chunksize
+    }
+    return pd.read_csv(file, dialect='excel', **select_not_null(kwd))
+
+
+def parse_tsv(file: IO, chunksize: int = None) -> pd.DataFrame:
+    kwd = {
+        chunksize: chunksize
+    }
+    return pd.read_csv(file, dialect='excel-tab', **select_not_null(kwd))
+
+
+def parse_imdb_list(file: IO, chunksize: int) -> pd.DataFrame:
+
+    return pd.DataFrame
+
+MAP = {
+    'csv': parse_csv,
+    'tsv': parse_tsv,
+    'list': parse_imdb_list,
+}

--- a/sa_autowrite/parsers.py
+++ b/sa_autowrite/parsers.py
@@ -1,7 +1,9 @@
 from abc import abstractmethod
-from typing import IO, Iterable, Sequence, overload, TypeVar
+from pathlib import Path
+from typing import IO, Iterable, Sequence, overload, TypeVar, Union, Iterator, Tuple
 from utils.dict_utils import select_not_null
 import pandas as pd
+import re
 
 __all__ = ['MAP']
 
@@ -20,9 +22,206 @@ def parse_tsv(file: IO, chunksize: int = None) -> pd.DataFrame:
     return pd.read_csv(file, dialect='excel-tab', **select_not_null(kwd))
 
 
-def parse_imdb_list(file: IO, chunksize: int) -> pd.DataFrame:
+def get_data_lines(filename: Union[str, Path], encoding: str = 'utf-8') -> str:
+    with open(filename, 'r', encoding=encoding) as file:
+        line = ''
+        while not line.startswith('---'):
+            line = file.readline()
+        # maybe do sth or maybe not
+        while not line.startswith('==='):
+            line = file.readline()
+        # now at data
+        while line != '':
+            line = file.readline()
+            yield line
+    raise StopIteration
 
-    return pd.DataFrame
+
+def consume_str_until(it: Iterator[str], stop: str) -> None:
+    """Reads an iterator of str until 'stop'.
+
+    Args:
+        it: The iterator of the string to read
+        stop: The character to stop
+
+    Returns:
+        None
+
+    Notes:
+        Consumes the stop character in the iterator.
+
+    Warnings:
+        'stop' must be a character but isn't checked to increase performance(?).
+    """
+    while next(it) != stop:
+        pass
+    return
+
+
+def read_str_until(it: Iterator[str], stop: str) -> str:
+    """Returns the string before stop.
+
+    Args:
+        it: The iterator of the string to read
+        stop: The character to stop
+
+    Notes:
+        Consumes the stop character in the iterator.
+
+    Warnings:
+        'stop' must be a character but isn't checked to increase performance(?).
+    """
+    lst = []
+    c = next(it)
+    while c != stop:
+        lst.append(c)
+        c = next(it)
+    return ''.join(lst)
+
+
+def read_str_untils(it: Iterator[str], *stops: str) -> (str, str):
+    """Returns the string before stop.
+
+    Args:
+        it: The iterator of the string to read
+        *stop: The characters to stop
+
+    Notes:
+        Consumes the stop character in the iterator.
+
+    Warnings:
+        'stop' must be a character but isn't checked to increase performance(?).
+
+    Returns:
+        result, stopped character
+    """
+    lst = []
+    c = next(it)
+    while c not in stops:
+        lst.append(c)
+        c = next(it)
+    return ''.join(lst), c
+
+
+def parse_line_iter(line: str) -> Tuple[str, str, str, str, bool, str]:
+    """Parse a line in IMDB list file using iterator method.
+
+    Args:
+        line: The line to parse
+
+    Returns:
+        title, year, episode, episode_num, and rest.
+        episode and episode_num will be None if it doesn't exist.
+
+    Examples:
+        >>> parse_line_iter('"!Next?" (1994)\\t\\t\\t\\t\\t\\tItaly\\n')  # countries.list
+        ('!Next?', '1994', None, None, 'Italy')
+        >>> parse_line_iter('"#1 Single" (2006)\\t\\t\\t\\t\\tUSA\\n')
+        ('#1 Single', '2006', None, None, 'USA')
+        >>> parse_line_iter('"#15SecondScare" (2015)\\t\\t\\t\\t\\tUSA\\n')
+        ('#15SecondScare', '2015', None, None, 'USA')
+        >>> parse_line_iter('"#15SecondScare" (2015) {Because We Don\\'t Want You to Fall Asleep (#1.3)}\\tUSA\\n')
+        ('#15SecondScare', '2015', "Because We Don't Want You to Fall Asleep", '1.3', 'USA')
+        >>> parse_line_iter('"#1 Single" (2006) {Wingman (#1.6)}\\t\\t\\tStick Figure Productions [us]\\n')  #production-companies.list
+        ('#1 Single', '2006', 'Wingman', '1.6', 'Stick Figure Productions [us]')
+        >>> parse_line_iter('"#1MinuteNightmare" (2014)\\t\\t\\t\\tSuperfreakMedia [gb]\\n')  #production-companies.list
+        ('#1MinuteNightmare', '2014', None, None, 'SuperfreakMedia [gb]')
+        >>> parse_line_iter('"#7DaysLater" (2013)\\t\\t\\t\\t\\tLudo Studio [au]\\n')  #production-companies.list
+        ('#7DaysLater', '2013', None, None, 'Ludo Studio [au]')
+        >>> parse_line_iter('"#LoveMonkeyChocolateFlowers" (2014)\\t\\t\\tUK:PG\\n')  #certificates.list
+        ('#LoveMonkeyChocolateFlowers', '2014', None, None, 'UK:PG')
+        >>> parse_line_iter('"$#*! My Dad Says" (2010)\\t\\t\\t\\tAustralia:PG\\n')  #certificates.list
+        ('$#*! My Dad Says', '2010', None, None, 'Australia:PG')
+        >>> parse_line_iter('"$#*! My Dad Says" (2010) {Code Ed (#1.4)}\\t\\tNetherlands:6\\n')  #certificates.list
+        ('$#*! My Dad Says', '2010', 'Code Ed', '1.4', 'Netherlands:6')
+        >>> parse_line_iter('"1714. El preu de la llibertat" (2014) {{SUSPENDED}}\\tSpain\\n')  #countries.list
+        ('1714. El preu de la llibertat', '2014', None, None, None, 'Spain')
+        >>> parse_line_iter('"18 Wheels of Justice" (2000) {(2000-03-29)}\\t\\tUSA\\n')  #countries.list
+        ('$#*! My Dad Says', '2010', 'Code Ed', '1.4', 'Netherlands:6')
+    """
+    it = iter(line)
+    if next(it) != '"':
+        raise AssertionError(f"line '{line}' has incorrect format (expecting '\"' at position 0)")
+    title = read_str_until(it, '"')
+    consume_str_until(it, '(')
+    year = read_str_until(it, ')')
+    c = next(it)
+    if c == ' ':
+        if next(it) != '{':
+            raise AssertionError(f"line '{line}' has incorrect format (expecting '{{')")
+        try:
+            episode, stop = read_str_untils(it, '(', '}')
+        except StopIteration as e:
+            raise AssertionError(f"line '{line}' has incorrect format (expecting '(')") from e
+        episode = episode.rstrip(' ')
+        if stop == '(':
+            if episode:
+                if next(it) != '#':
+                    raise AssertionError(f"line '{line}' has incorrect format (expecting '#')")
+                episode_num = read_str_until(it, ')')
+                if next(it) != '}':
+                    raise AssertionError(f"line '{line}' has incorrect format (expecting '}}')")
+            else:
+                episode = ''.join(['(', read_str_until(it, ')'), ')'])
+                if next(it) != '}':
+                    raise AssertionError(f"line '{line}' has incorrect format (expecting '}}')")
+                episode_num = None
+        else:
+            episode_num = None
+    else:
+        episode = None
+        episode_num = None
+    c = next(it)
+    while c == '\t':
+        c = next(it)
+    rest = c + read_str_until(it, '\n')
+    is_suspended = False
+    return title, year, episode, episode_num, is_suspended, rest
+
+
+def parse_line_re(line: str) -> dict:
+    """Parse a line in IMDB list file using regex method.
+
+    Args:
+        line: The line to parse
+
+    Returns:
+        title, year, episode, episode_num, and rest.
+        episode and episode_num will be None if it doesn't exist.
+
+    Examples:
+        See unittest.
+    """
+    m = re.match(r'\"?(?P<title>[^\"]*)\"? \((?P<year>(\d\d\d\d)|(\?\?\?\?))(/(?P<roman>[IVX]+))?\)( \((?P<type>\S*)\))?( {(?P<episode_info>.*)?})?\t+(?P<data>.*)\n?', line)
+    dct = m.groupdict()
+    year = dct.get('year')
+    out = {
+        'title': dct.get('title'),
+        'year': None if year == '????' else int(year),
+        'roman': dct.get('roman'),
+        'type': dct.get('type'),
+        'episode_info': dct.get('episode_info'),
+        'data': dct.get('data'),
+    }
+    return out
+
+def parse_imdb_list(filename: Union[str, Path], *, chunksize: int, encoding: str = None) -> pd.DataFrame:
+    count = 0
+    lst = []
+    for line in get_data_lines(filename, encoding=encoding):
+        title, year, episode, episode_num, rest = parse_line_iter(line)
+        lst.append({
+            'title': title,
+            'year': year,
+            'episode': episode,
+            'episode_num': episode_num,
+            'rest': rest,
+        })
+        count += 1
+        if count % chunksize == 0:
+            yield pd.DataFrame(lst)
+            lst = []
+    raise StopIteration
 
 MAP = {
     'csv': parse_csv,

--- a/sa_autowrite/parsers.py
+++ b/sa_autowrite/parsers.py
@@ -114,30 +114,30 @@ def parse_line_iter(line: str) -> Tuple[str, str, str, str, bool, str]:
         episode and episode_num will be None if it doesn't exist.
 
     Examples:
-        >>> parse_line_iter('"!Next?" (1994)\\t\\t\\t\\t\\t\\tItaly\\n')  # countries.list
-        ('!Next?', '1994', None, None, 'Italy')
-        >>> parse_line_iter('"#1 Single" (2006)\\t\\t\\t\\t\\tUSA\\n')
-        ('#1 Single', '2006', None, None, 'USA')
-        >>> parse_line_iter('"#15SecondScare" (2015)\\t\\t\\t\\t\\tUSA\\n')
-        ('#15SecondScare', '2015', None, None, 'USA')
-        >>> parse_line_iter('"#15SecondScare" (2015) {Because We Don\\'t Want You to Fall Asleep (#1.3)}\\tUSA\\n')
-        ('#15SecondScare', '2015', "Because We Don't Want You to Fall Asleep", '1.3', 'USA')
-        >>> parse_line_iter('"#1 Single" (2006) {Wingman (#1.6)}\\t\\t\\tStick Figure Productions [us]\\n')  #production-companies.list
-        ('#1 Single', '2006', 'Wingman', '1.6', 'Stick Figure Productions [us]')
-        >>> parse_line_iter('"#1MinuteNightmare" (2014)\\t\\t\\t\\tSuperfreakMedia [gb]\\n')  #production-companies.list
-        ('#1MinuteNightmare', '2014', None, None, 'SuperfreakMedia [gb]')
-        >>> parse_line_iter('"#7DaysLater" (2013)\\t\\t\\t\\t\\tLudo Studio [au]\\n')  #production-companies.list
-        ('#7DaysLater', '2013', None, None, 'Ludo Studio [au]')
-        >>> parse_line_iter('"#LoveMonkeyChocolateFlowers" (2014)\\t\\t\\tUK:PG\\n')  #certificates.list
-        ('#LoveMonkeyChocolateFlowers', '2014', None, None, 'UK:PG')
-        >>> parse_line_iter('"$#*! My Dad Says" (2010)\\t\\t\\t\\tAustralia:PG\\n')  #certificates.list
-        ('$#*! My Dad Says', '2010', None, None, 'Australia:PG')
-        >>> parse_line_iter('"$#*! My Dad Says" (2010) {Code Ed (#1.4)}\\t\\tNetherlands:6\\n')  #certificates.list
-        ('$#*! My Dad Says', '2010', 'Code Ed', '1.4', 'Netherlands:6')
-        >>> parse_line_iter('"1714. El preu de la llibertat" (2014) {{SUSPENDED}}\\tSpain\\n')  #countries.list
-        ('1714. El preu de la llibertat', '2014', None, None, None, 'Spain')
-        >>> parse_line_iter('"18 Wheels of Justice" (2000) {(2000-03-29)}\\t\\tUSA\\n')  #countries.list
-        ('$#*! My Dad Says', '2010', 'Code Ed', '1.4', 'Netherlands:6')
+        # >>> parse_line_iter('"!Next?" (1994)\\t\\t\\t\\t\\t\\tItaly\\n')  # countries.list
+        # ('!Next?', '1994', None, None, 'Italy')
+        # >>> parse_line_iter('"#1 Single" (2006)\\t\\t\\t\\t\\tUSA\\n')
+        # ('#1 Single', '2006', None, None, 'USA')
+        # >>> parse_line_iter('"#15SecondScare" (2015)\\t\\t\\t\\t\\tUSA\\n')
+        # ('#15SecondScare', '2015', None, None, 'USA')
+        # >>> parse_line_iter('"#15SecondScare" (2015) {Because We Don\\'t Want You to Fall Asleep (#1.3)}\\tUSA\\n')
+        # ('#15SecondScare', '2015', "Because We Don't Want You to Fall Asleep", '1.3', 'USA')
+        # >>> parse_line_iter('"#1 Single" (2006) {Wingman (#1.6)}\\t\\t\\tStick Figure Productions [us]\\n')  #production-companies.list
+        # ('#1 Single', '2006', 'Wingman', '1.6', 'Stick Figure Productions [us]')
+        # >>> parse_line_iter('"#1MinuteNightmare" (2014)\\t\\t\\t\\tSuperfreakMedia [gb]\\n')  #production-companies.list
+        # ('#1MinuteNightmare', '2014', None, None, 'SuperfreakMedia [gb]')
+        # >>> parse_line_iter('"#7DaysLater" (2013)\\t\\t\\t\\t\\tLudo Studio [au]\\n')  #production-companies.list
+        # ('#7DaysLater', '2013', None, None, 'Ludo Studio [au]')
+        # >>> parse_line_iter('"#LoveMonkeyChocolateFlowers" (2014)\\t\\t\\tUK:PG\\n')  #certificates.list
+        # ('#LoveMonkeyChocolateFlowers', '2014', None, None, 'UK:PG')
+        # >>> parse_line_iter('"$#*! My Dad Says" (2010)\\t\\t\\t\\tAustralia:PG\\n')  #certificates.list
+        # ('$#*! My Dad Says', '2010', None, None, 'Australia:PG')
+        # >>> parse_line_iter('"$#*! My Dad Says" (2010) {Code Ed (#1.4)}\\t\\tNetherlands:6\\n')  #certificates.list
+        # ('$#*! My Dad Says', '2010', 'Code Ed', '1.4', 'Netherlands:6')
+        # >>> parse_line_iter('"1714. El preu de la llibertat" (2014) {{SUSPENDED}}\\tSpain\\n')  #countries.list
+        # ('1714. El preu de la llibertat', '2014', None, None, None, 'Spain')
+        # >>> parse_line_iter('"18 Wheels of Justice" (2000) {(2000-03-29)}\\t\\tUSA\\n')  #countries.list
+        # ('$#*! My Dad Says', '2010', 'Code Ed', '1.4', 'Netherlands:6')
     """
     it = iter(line)
     if next(it) != '"':

--- a/tests/test_autowrite.py
+++ b/tests/test_autowrite.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 from dirs import ROOT_DIR
 from extended_csv import read_xsv_file
-from sa_autowrite.main import write_model
+from sa_autowrite.create import write_model
 
 
 class TestAutowrite(unittest.TestCase):

--- a/tests/test_imdb_list.py
+++ b/tests/test_imdb_list.py
@@ -1,0 +1,75 @@
+import unittest
+from doctest import DocTestSuite
+
+from sa_autowrite import parsers
+from sa_autowrite.parsers import parse_line_re
+
+
+def load_tests(loader: unittest.TestLoader, tests: unittest.TestSuite, ignore) -> unittest.TestSuite:
+    tests.addTests(map(DocTestSuite, (parsers,)))
+    return tests
+
+
+class TestParsers(unittest.TestCase):
+
+    def test_parse_line_re(self):
+        test_cases = [
+            (
+                '"!Next?" (1994)\t\t\t\t\t\tItaly\n', {
+                    'title': '!Next?',
+                    'year': 1994,
+                    'roman': None,
+                    'type': None,
+                    'episode_info': None,
+                    'data': 'Italy',
+                }
+            ),
+            (
+                '"#15SecondScare" (2015)\t\t\t\t\tUSA\n', {
+                    'title': '#15SecondScare',
+                    'year': 2015,
+                    'roman': None,
+                    'type': None,
+                    'episode_info': None,
+                    'data': 'USA',
+                }
+            ),
+            (
+                '"#15SecondScare" (2015) {Because We Don\'t Want You to Fall Asleep (#1.3)}\tUSA\n', {
+                    'title': '#15SecondScare',
+                    'year': 2015,
+                    'roman': None,
+                    'type': None,
+                    'episode_info': "Because We Don't Want You to Fall Asleep (#1.3)",
+                    'data': 'USA',
+                }
+            ),
+            (
+                '"#1 Single" (2006) {Wingman (#1.6)}\t\t\tStick Figure Productions [us]\n', {
+                    'title': '#1 Single',
+                    'year': 2006,
+                    'roman': None,
+                    'type': None,
+                    'episode_info': "Wingman (#1.6)",
+                    'data': 'Stick Figure Productions [us]',
+                },
+            ),
+            (
+                '"#LoveMonkeyChocolateFlowers" (2014)\t\t\tUK:PG\n', {
+                    'title': '#LoveMonkeyChocolateFlowers',
+                    'year': 2014,
+                    'roman': None,
+                    'type': None,
+                    'episode_info': None,
+                    'data': 'UK:PG',
+                },
+            ),
+        ]
+        for string, expected in test_cases:
+            with self.subTest(f"{string=},{expected=}"):
+                result = parse_line_re(string)
+                self.assertEqual(expected, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils/iter.py
+++ b/utils/iter.py
@@ -1,0 +1,28 @@
+from itertools import tee, chain
+from typing import Iterable, overload
+
+__all__ = ['pairwise', 'remove_consecs']
+
+
+def pairwise(iterable: Iterable) -> zip:
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    a, b = tee(iterable)
+    next(b, None)
+    return zip(a, b)
+
+
+@overload
+def remove_consecs(lst: list) -> list: ...
+@overload
+def remove_consecs(lst: list, o: object) -> Iterable: ...
+def remove_consecs(lst: list, o: object = None) -> Iterable:
+    """Returns a list with the consecutive 'o' (if specified) removed.
+
+    Args:
+        lst: List of things
+        o: Things to remove if appears consecutively.
+            If None remove all consecs.
+    """
+    if o is None:
+        raise NotImplementedError
+    return chain((curr for curr, nxt in pairwise(lst) if not (curr == nxt == o)), lst[-1])

--- a/utils/str_utils.py
+++ b/utils/str_utils.py
@@ -1,6 +1,29 @@
 import string
 
-__all__ = ['snake_to_camel', 'camel_to_snake', 'to_all_caps', 'snake_to_capwords']
+from utils.iter import remove_consecs
+
+__all__ = ['snake_to_camel', 'camel_to_snake', 'to_all_caps', 'snake_to_capwords', 'snake_case']
+
+
+def snake_case(s: str) -> str:
+    """Convert string into snake case.
+    Join punctuation (-, space, .) with underscore
+
+    Args:
+        string: String to convert.
+
+    Returns:
+        string: Snake cased string.
+    """
+    lst = []
+    for c in s:
+        if c in '-.' + string.whitespace:
+            lst.append('_')
+        elif c in string.ascii_uppercase:
+            lst.extend(['_', c.lower()])
+        else:
+            lst.append(c)
+    return ''.join(remove_consecs(lst, '_'))
 
 
 def snake_to_camel(s: str) -> str:

--- a/utils/str_utils.py
+++ b/utils/str_utils.py
@@ -1,6 +1,6 @@
 import string
 
-__all__ = ['snake_to_camel', 'camel_to_snake', 'to_all_caps']
+__all__ = ['snake_to_camel', 'camel_to_snake', 'to_all_caps', 'snake_to_capwords']
 
 
 def snake_to_camel(s: str) -> str:
@@ -22,6 +22,33 @@ def snake_to_camel(s: str) -> str:
         return first + ''.join(s.title() for s in others)
     except ValueError:
         return s
+
+
+def snake_to_capwords(s: str) -> str:
+    """Returns a new str in CapWords, given an str in snake_case.
+    Removes all underscore before and after.
+
+    Examples:
+        >>> snake_to_capwords('snake_to_capwords')
+        'SnakeToCapwords'
+        >>> snake_to_capwords('__snake_to_capwords__')
+        'SnakeToCapwords'
+        >>> snake_to_capwords('camelCase')
+        Traceback (most recent call last):
+          ...
+        ValueError: original str is not in snake_case: 'camelCase'
+        >>> snake_to_capwords('lonesnake')
+        'Lonesnake'
+        >>> snake_to_capwords('title_akas')
+        'TitleAkas'
+    """
+    words = [word for word in s.split('_') if word]
+    if len(words) == 1:
+        for char in words[0]:
+            if char.isupper():
+                raise ValueError(f"original str is not in snake_case: '{s}'")
+        return s.title()
+    return ''.join(s.title() for s in words)
 
 
 def camel_to_snake(s: str) -> str:


### PR DESCRIPTION
### Fixes
- Increase performance by at least 2/3
- Add function to individually insert data `insert_xsv_data`
  - Specify rows to start and stop reading
  - Report rows read and committed
- Add function to read IMDb LIST files

### Changes
- New package structure
- Update `sa_autowrite/README.md`
- Remove dependency `stringcase`
- Auto-generated models added with user edits
- New module in utils: `utils/iter.py` (petition to start renaming utils modules for brevity)
- Auto-generated package now has `models = [...]` for convenience

### Depreciation warning
- Will depreciate `insert_data()` soon
- `parse_line_iter()` is depreciated. Do not use.

### Tests
- Part of the tests for `parse_line_re()` used to parse each line in IMDb LIST files.